### PR TITLE
fix bug of mouseup on inactive button not firing

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -323,10 +323,12 @@ class Tile {
 
 	enable = () => {
 		this.button.disabled = false;
+		this.button.style.pointerEvents = `auto`;
 	};
 
 	disable = () => {
 		this.button.disabled = true;
+		this.button.style.pointerEvents = `none`;
 	};
 
 	getHTMLButton = () => {


### PR DESCRIPTION
Fixed bug where mouseup on disabled doesn't work. Used pointer-action: none on disabled button