### PR TITLE
Fixed bug where board re-enables if mouseup only occurs after time is up

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -165,6 +165,7 @@ class BoggleBoard {
 	};
 
 	freeze = () => {
+		this.endWord();
 		for (const tile of this.tiles) {
 			tile.disable();
 		}

--- a/styles/boggle-container.css
+++ b/styles/boggle-container.css
@@ -36,7 +36,10 @@
 	box-shadow: rgba(0, 0, 0, 0.17) 0px -3px 5px 5px inset, rgba(0, 0, 0, 0.15) 0px -6px 8px 5px inset,
 		rgba(0, 0, 0, 0.1) 0px -20px 20px 0px inset;
 }
-
+.vibrate {
+	animation: vibration 0.5s ease-in;
+	animation-iteration-count: 5;
+}
 .tile-flip {
 	animation: tileflip 1s ease-in forwards;
 }
@@ -59,5 +62,40 @@
 	}
 	100% {
 		transform: rotateY(0deg);
+	}
+}
+@keyframes vibration {
+	0% {
+		transform: translate(1px, 1px) rotate(0deg);
+	}
+	10% {
+		transform: translate(-1px, -2px) rotate(-1deg);
+	}
+	20% {
+		transform: translate(-3px, 0px) rotate(1deg);
+	}
+	30% {
+		transform: translate(3px, 2px) rotate(0deg);
+	}
+	40% {
+		transform: translate(1px, -1px) rotate(1deg);
+	}
+	50% {
+		transform: translate(-1px, 2px) rotate(-1deg);
+	}
+	60% {
+		transform: translate(-3px, 1px) rotate(0deg);
+	}
+	70% {
+		transform: translate(3px, 1px) rotate(-1deg);
+	}
+	80% {
+		transform: translate(-1px, -1px) rotate(1deg);
+	}
+	90% {
+		transform: translate(1px, 2px) rotate(0deg);
+	}
+	100% {
+		transform: translate(1px, -2px) rotate(-1deg);
 	}
 }


### PR DESCRIPTION
If a word was in the middle of being selected when the timer runs out, the mouseup event could still fire, triggering a reset and thus re-enabling of the boggle tiles / buttons.

Fixed by calling endWord in the freeze function of boggleBoard, so that all the tiles and the current letter holder would be reset and then immediately disabled. 