### PR TITLE
Disabled tiles while they are flipping at start of game

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -159,8 +159,10 @@ class BoggleBoard {
 		for (let i = 0; i < this.tiles.length; i++) {
 			let tile = this.tiles[i];
 			let randomLetter = this.boggleDice[i][Math.floor(Math.random() * 6)];
+			tile.disable();
 			tile.setLetter(randomLetter);
-			tile.enable();
+			tile.animate();
+			setTimeout(() => tile.enable(), 1000);
 		}
 	};
 
@@ -322,7 +324,6 @@ class Tile {
 		}
 		this.letter = letter;
 
-		this.animate();
 		this.button.innerText = letter;
 	};
 


### PR DESCRIPTION
Disable tiles during the flip animation at the start of the game by modifying the boggleBoard.reset() function. First set the tiles to disabled, run tiles.animate(), then use a setTimeout enable the buttons when the animation is over.